### PR TITLE
Added restart capability

### DIFF
--- a/epoch_axial/example_decks/restart.deck
+++ b/epoch_axial/example_decks/restart.deck
@@ -1,3 +1,7 @@
+# This input deck is a modified version of the Gaussian beam deck. It is set-up
+# such that each output dump is a restart file. To restart from a particular
+# sdf file, uncomment the "restart_snapshot" line in the control block.
+
 begin:control
   nx = 500
   ny = 100
@@ -12,6 +16,10 @@ begin:control
 
   stdout_frequency = 10
   n_mode = 2
+  
+  # This line is currently set to restart from 0002.sdf. Run this simulation
+  # normally first to generate this restart file. 
+  # restart_snapshot = 2
 end:control
 
 
@@ -47,10 +55,10 @@ begin:laser
 end:laser
 
 begin:output
-  name = normal
 
   # Simulated time between output dumps
   dt_snapshot = 25 * femto
+  restart_dump_every = 0
 
   # Properties on grid
   grid = always
@@ -60,4 +68,5 @@ begin:output
   bxm = always
   brm = always
   btm = always
+ 
 end:output

--- a/epoch_axial/src/constants.F90
+++ b/epoch_axial/src/constants.F90
@@ -625,12 +625,18 @@ MODULE constants
   INTEGER, PARAMETER :: c_dump_bxm               = 75
   INTEGER, PARAMETER :: c_dump_brm               = 76
   INTEGER, PARAMETER :: c_dump_btm               = 77
-  INTEGER, PARAMETER :: c_dump_jxm               = 78
-  INTEGER, PARAMETER :: c_dump_jrm               = 79
-  INTEGER, PARAMETER :: c_dump_jtm               = 80
-  INTEGER, PARAMETER :: c_dump_probe_time        = 81
-  INTEGER, PARAMETER :: c_dump_num_dens_mode     = 82
-  INTEGER, PARAMETER :: num_vars_to_dump         = 82
+  INTEGER, PARAMETER :: c_dump_bxm_old           = 78
+  INTEGER, PARAMETER :: c_dump_brm_old           = 79
+  INTEGER, PARAMETER :: c_dump_btm_old           = 80
+  INTEGER, PARAMETER :: c_dump_jxm               = 81
+  INTEGER, PARAMETER :: c_dump_jrm               = 82
+  INTEGER, PARAMETER :: c_dump_jtm               = 83
+  INTEGER, PARAMETER :: c_dump_jxm_old           = 84
+  INTEGER, PARAMETER :: c_dump_jrm_old           = 85
+  INTEGER, PARAMETER :: c_dump_jtm_old           = 86
+  INTEGER, PARAMETER :: c_dump_probe_time        = 87
+  INTEGER, PARAMETER :: c_dump_num_dens_mode     = 88
+  INTEGER, PARAMETER :: num_vars_to_dump         = 88
 
   INTEGER, PARAMETER :: c_subset_random     = 1
   INTEGER, PARAMETER :: c_subset_gamma_min  = 2

--- a/epoch_axial/src/deck/deck_io_block.F90
+++ b/epoch_axial/src/deck/deck_io_block.F90
@@ -657,6 +657,15 @@ CONTAINS
     ELSE IF (str_cmp(element, 'btm')) THEN
       elementselected = c_dump_btm
 
+    ELSE IF (str_cmp(element, 'bxm_old')) THEN
+      elementselected = c_dump_bxm_old
+
+    ELSE IF (str_cmp(element, 'brm_old')) THEN
+      elementselected = c_dump_brm_old
+
+    ELSE IF (str_cmp(element, 'btm_old')) THEN
+      elementselected = c_dump_btm_old
+
     ELSE IF (str_cmp(element, 'jxm')) THEN
       elementselected = c_dump_jxm
 
@@ -665,6 +674,15 @@ CONTAINS
 
     ELSE IF (str_cmp(element, 'jtm')) THEN
       elementselected = c_dump_jtm
+
+    ELSE IF (str_cmp(element, 'jxm_old')) THEN
+      elementselected = c_dump_jxm_old
+
+    ELSE IF (str_cmp(element, 'jrm_old')) THEN
+      elementselected = c_dump_jrm_old
+
+    ELSE IF (str_cmp(element, 'jtm_old')) THEN
+      elementselected = c_dump_jtm_old
 
     ELSE IF (str_cmp(element, 'ekbar') &
         .OR. str_cmp(element, 'average_particle_energy')) THEN
@@ -922,9 +940,15 @@ CONTAINS
         IF (mask_element == c_dump_bxm) bad = .FALSE.
         IF (mask_element == c_dump_brm) bad = .FALSE.
         IF (mask_element == c_dump_btm) bad = .FALSE.
+        IF (mask_element == c_dump_bxm_old) bad = .FALSE.
+        IF (mask_element == c_dump_brm_old) bad = .FALSE.
+        IF (mask_element == c_dump_btm_old) bad = .FALSE.
         IF (mask_element == c_dump_jxm) bad = .FALSE.
         IF (mask_element == c_dump_jrm) bad = .FALSE.
         IF (mask_element == c_dump_jtm) bad = .FALSE.
+        IF (mask_element == c_dump_jxm_old) bad = .FALSE.
+        IF (mask_element == c_dump_jrm_old) bad = .FALSE.
+        IF (mask_element == c_dump_jtm_old) bad = .FALSE.
         IF (mask_element == c_dump_poynt_flux) bad = .FALSE.
 
         ! Unset 'no_sum' dumpmask for grid variables
@@ -1152,24 +1176,6 @@ CONTAINS
     ! Fields
     io_block%dumpmask(c_dump_grid) = &
         IOR(io_block%dumpmask(c_dump_grid), c_io_restartable)
-    io_block%dumpmask(c_dump_ex) = &
-        IOR(io_block%dumpmask(c_dump_ex), c_io_restartable)
-    io_block%dumpmask(c_dump_ey) = &
-        IOR(io_block%dumpmask(c_dump_ey), c_io_restartable)
-    io_block%dumpmask(c_dump_ez) = &
-        IOR(io_block%dumpmask(c_dump_ez), c_io_restartable)
-    io_block%dumpmask(c_dump_bx) = &
-        IOR(io_block%dumpmask(c_dump_bx), c_io_restartable)
-    io_block%dumpmask(c_dump_by) = &
-        IOR(io_block%dumpmask(c_dump_by), c_io_restartable)
-    io_block%dumpmask(c_dump_bz) = &
-        IOR(io_block%dumpmask(c_dump_bz), c_io_restartable)
-    io_block%dumpmask(c_dump_jx) = &
-        IOR(io_block%dumpmask(c_dump_jx), c_io_restartable)
-    io_block%dumpmask(c_dump_jy) = &
-        IOR(io_block%dumpmask(c_dump_jy), c_io_restartable)
-    io_block%dumpmask(c_dump_jz) = &
-        IOR(io_block%dumpmask(c_dump_jz), c_io_restartable)
     io_block%dumpmask(c_dump_exm) = &
         IOR(io_block%dumpmask(c_dump_exm), c_io_restartable)
     io_block%dumpmask(c_dump_erm) = &
@@ -1182,12 +1188,24 @@ CONTAINS
         IOR(io_block%dumpmask(c_dump_brm), c_io_restartable)
     io_block%dumpmask(c_dump_btm) = &
         IOR(io_block%dumpmask(c_dump_btm), c_io_restartable)
+    io_block%dumpmask(c_dump_bxm_old) = &
+        IOR(io_block%dumpmask(c_dump_bxm_old), c_io_restartable)
+    io_block%dumpmask(c_dump_brm_old) = &
+        IOR(io_block%dumpmask(c_dump_brm_old), c_io_restartable)
+    io_block%dumpmask(c_dump_btm_old) = &
+        IOR(io_block%dumpmask(c_dump_btm_old), c_io_restartable)
     io_block%dumpmask(c_dump_jxm) = &
         IOR(io_block%dumpmask(c_dump_jxm), c_io_restartable)
     io_block%dumpmask(c_dump_jrm) = &
         IOR(io_block%dumpmask(c_dump_jrm), c_io_restartable)
     io_block%dumpmask(c_dump_jtm) = &
         IOR(io_block%dumpmask(c_dump_jtm), c_io_restartable)
+    io_block%dumpmask(c_dump_jxm_old) = &
+        IOR(io_block%dumpmask(c_dump_jxm_old), c_io_restartable)
+    io_block%dumpmask(c_dump_jrm_old) = &
+        IOR(io_block%dumpmask(c_dump_jrm_old), c_io_restartable)
+    io_block%dumpmask(c_dump_jtm_old) = &
+        IOR(io_block%dumpmask(c_dump_jtm_old), c_io_restartable)
     ! CPML boundaries
     io_block%dumpmask(c_dump_cpml_psi_eyx) = &
         IOR(io_block%dumpmask(c_dump_cpml_psi_eyx), c_io_restartable)

--- a/epoch_axial/src/epoch2d.F90
+++ b/epoch_axial/src/epoch2d.F90
@@ -149,6 +149,7 @@ PROGRAM pic
       CALL bfield_final_bcs
     ELSE
       time = time + dt / 2.0_num
+      CALL old_field_bcs
       CALL update_eb_fields_final
       CALL moving_window
     END IF

--- a/epoch_axial/src/housekeeping/mpi_subtype_control.f90
+++ b/epoch_axial/src/housekeeping/mpi_subtype_control.f90
@@ -378,6 +378,14 @@ CONTAINS
     subarray_field_r4 = create_current_field_subarray(ng, MPI_REAL4)
     subarray_field_big_r4 = create_current_field_subarray(jng, MPI_REAL4)
 
+    subtype_mode = create_current_field_mode_subtype(mpireal)
+    subarray_mode = create_current_field_mode_subarray(ng, mpireal)
+    subarray_mode_big = create_current_field_mode_subarray(jng, mpireal)
+
+    subtype_mode_r4 = create_current_field_mode_subtype(MPI_REAL4)
+    subarray_mode_r4 = create_current_field_mode_subarray(ng, MPI_REAL4)
+    subarray_mode_big_r4 = create_current_field_mode_subarray(jng, MPI_REAL4)
+
     ALLOCATE(species_subtypes(n_species))
     ALLOCATE(species_subtypes_i4(n_species))
     ALLOCATE(species_subtypes_i8(n_species))

--- a/epoch_axial/src/laser.f90
+++ b/epoch_axial/src/laser.f90
@@ -417,7 +417,7 @@ CONTAINS
     REAL(num), DIMENSION(:), ALLOCATABLE :: source1, source2
     COMPLEX(num), DIMENSION(:), ALLOCATABLE :: source_r, source_t
     REAL(num), DIMENSION(:), ALLOCATABLE :: r_d_vals
-    INTEGER :: n, ir, im, ir_l
+    INTEGER :: n, ir, im, ir_l, ir_h
     TYPE(laser_block), POINTER :: current
 
     n = c_bd_x_min
@@ -487,12 +487,12 @@ CONTAINS
         source_r = 0.0_num
       END IF
 
-      btm(1,0:ny,im) = sum * ( 4.0_num * source_t(0:ny) &
-          + 2.0_num * (erm_x_min(0:ny,im) + c * btm_x_min(0:ny,im)) &
-          - 2.0_num * erm(1,0:ny,im) &
-          + imagi * im * c**2 * dt * bxm(1,0:ny,im) / r_d_vals &
-          + dt_eps * jrm(1,0:ny,im) &
-          + diff * btm(2,0:ny,im))
+      btm(1,1:ny,im) = sum * ( 4.0_num * source_t(1:ny) &
+          + 2.0_num * (erm_x_min(1:ny,im) + c * btm_x_min(1:ny,im)) &
+          - 2.0_num * erm(1,1:ny,im) &
+          + imagi * im * c**2 * dt * bxm(1,1:ny,im) / r_d_vals &
+          + dt_eps * jrm(1,1:ny,im) &
+          + diff * btm(2,1:ny,im))
 
       ! Set the low ir limit for the Brm field
       IF (y_min_boundary) THEN
@@ -501,12 +501,17 @@ CONTAINS
       ELSE
         ir_l = 0
       END IF
-      brm(1,ir_l:ny,im) = sum * (-4.0_num * source_r(ir_l:ny) &
-          - 2.0_num * (etm_x_min(ir_l:ny,im) + c * brm_x_min(ir_l:ny,im)) &
-          + 2.0_num * etm(1,ir_l:ny,im) &
-          - lr * (bxm(1,ir_l+1:ny+1,im) - bxm(1,ir_l:ny,im)) &
-          - dt_eps * jtm(1,ir_l:ny,im) &
-          + diff * brm(2,ir_l:ny,im))
+      IF (y_max_boundary) THEN 
+        ir_h = ny-1
+      ELSE
+        ir_h = ny
+      END IF
+      brm(1,ir_l:ir_h,im) = sum * (-4.0_num * source_r(ir_l:ir_h) &
+          - 2.0_num * (etm_x_min(ir_l:ir_h,im) + c * brm_x_min(ir_l:ir_h,im)) &
+          + 2.0_num * etm(1,ir_l:ir_h,im) &
+          - lr * (bxm(1,ir_l+1:ir_h+1,im) - bxm(1,ir_l:ir_h,im)) &
+          - dt_eps * jtm(1,ir_l:ir_h,im) &
+          + diff * brm(2,ir_l:ir_h,im))
 
     END DO
 
@@ -525,7 +530,7 @@ CONTAINS
     REAL(num), DIMENSION(:), ALLOCATABLE :: source1, source2
     COMPLEX(num), DIMENSION(:), ALLOCATABLE :: source_t, source_r
     REAL(num), DIMENSION(:), ALLOCATABLE :: r_d_vals
-    INTEGER :: laserpos, n, ir, im, ir_l
+    INTEGER :: laserpos, n, ir, im, ir_l, ir_h
     TYPE(laser_block), POINTER :: current
 
     n = c_bd_x_max
@@ -596,12 +601,12 @@ CONTAINS
         source_r = 0.0_num
       END IF
 
-      btm(nx,0:ny,im) = sum * ( -4.0_num * source_t &
-          - 2.0_num * (erm_x_max(0:ny,im) + c * btm_x_max(0:ny,im)) &
-          + 2.0_num * erm(nx-1,0:ny,im) &
-          - imagi * im * c**2 * dt * bxm(nx-1,0:ny,im) / r_d_vals &
-          - dt_eps * jrm(nx-1,0:ny,im) &
-          + diff * btm(nx-1,0:ny,im))
+      btm(nx,1:ny,im) = sum * ( -4.0_num * source_t &
+          - 2.0_num * (erm_x_max(1:ny,im) + c * btm_x_max(1:ny,im)) &
+          + 2.0_num * erm(nx-1,1:ny,im) &
+          - imagi * im * c**2 * dt * bxm(nx-1,1:ny,im) / r_d_vals &
+          - dt_eps * jrm(nx-1,1:ny,im) &
+          + diff * btm(nx-1,1:ny,im))
 
       ! Set the low ir limit for the Brm field
       IF (y_min_boundary) THEN
@@ -610,12 +615,17 @@ CONTAINS
       ELSE
         ir_l = 0
       END IF
-      brm(nx,ir_l:ny,im) = sum * ( 4.0_num * source_r(ir_l:ny) &
-          + 2.0_num * (etm_x_max(ir_l:ny,im) + c * brm_x_max(ir_l:ny,im)) &
-          - 2.0_num * etm(nx-1,ir_l:ny,im) &
-          + lr * (bxm(nx-1,ir_l+1:ny+1,im) - bxm(nx-1,ir_l:ny,im)) &
-          + dt_eps * jtm(nx-1,ir_l:ny,im) &
-          + diff * brm(nx-1,ir_l:ny,im))
+      IF (y_max_boundary) THEN 
+        ir_h = ny-1
+      ELSE
+        ir_h = ny
+      END IF
+      brm(nx,ir_l:ir_h,im) = sum * ( 4.0_num * source_r(ir_l:ir_h) &
+          + 2.0_num * (etm_x_max(ir_l:ir_h,im) + c * brm_x_max(ir_l:ir_h,im)) &
+          - 2.0_num * etm(nx-1,ir_l:ir_h,im) &
+          + lr * (bxm(nx-1,ir_l+1:ir_h+1,im) - bxm(nx-1,ir_l:ir_h,im)) &
+          + dt_eps * jtm(nx-1,ir_l:ir_h,im) &
+          + diff * brm(nx-1,ir_l:ir_h,im))
     END DO
 
     DEALLOCATE(source1, source2, source_r, source_t, r_d_vals)
@@ -629,7 +639,7 @@ CONTAINS
     REAL(num) :: t_env
     REAL(num) :: dtc2, inv_r, dtc2_4r, icdt_2r, lx, ly, sum_x, sum_t, dt_2eps
     REAL(num), DIMENSION(:), ALLOCATABLE :: source1, source2
-    INTEGER :: i, im
+    INTEGER :: i, im, ix_l, ix_h
     TYPE(laser_block), POINTER :: current
 
     dtc2 = dt * c**2
@@ -642,24 +652,39 @@ CONTAINS
     sum_t = 1.0_num / (ly + c + dtc2_4r)
     dt_2eps = 0.5_num * dt / epsilon0
 
-    DO im = 0, n_mode-1
-      bxm(0:nx,ny,im) = sum_x * (-bxm(0:nx,ny-1,im) * (c - ly) &
-          -bxm_old(0:nx,ny,im) * (-c + ly) &
-          -bxm_old(0:nx,ny-1,im) * (-c - ly) &
-          -c * dt * inv_r * etm(0:nx,ny-1,im) &
-          + 0.5_num * lx * (brm(1:nx+1,ny-1,im) - brm(0:nx,ny-1,im) &
-          + brm_old(1:nx+1,ny-1,im) - brm_old(0:nx,ny-1,im)) &
-          - icdt_2r * REAL(im, num) * (erm(0:nx,ny,im) + erm(0:nx,ny-1,im)) &
-          - dt_2eps * (jtm(0:nx,ny-1,im) + jtm_old(0:nx,ny-1,im)))
+    ! Ignore cells in the high-r simulation corners. Leave these for x-bcs
+    IF (x_min_boundary) THEN
+      ix_l = 1
+    ELSE
+      ix_l = 0
+    END IF
 
-      btm(0:nx,ny,im) = sum_t * (-btm(0:nx,ny-1,im) * (c - ly + dtc2_4r) &
-          -btm_old(0:nx,ny,im) * (-c + ly + dtc2_4r) &
-          -btm_old(0:nx,ny-1,im) * (-c - ly + dtc2_4r) &
-          - 0.5_num * lx / c * (erm(0:nx,ny,im) + erm(0:nx,ny-1,im) &
-          - erm(-1:nx-1,ny,im) - erm(-1:nx-1,ny-1,im)) &
-          - icdt_2r * REAL(im, num) * c * (brm(0:nx,ny-1,im) &
-          + brm_old(0:nx,ny-1,im)) &
-          + dt_2eps * (jxm(0:nx,ny-1,im) + jxm_old(0:nx,ny-1,im)))
+    IF (x_max_boundary) THEN
+      ix_h = nx-1
+    ELSE
+      ix_h = nx
+    END IF
+
+    DO im = 0, n_mode-1
+      bxm(ix_l:ix_h,ny,im) = sum_x * (-bxm(ix_l:ix_h,ny-1,im) * (c - ly) &
+          -bxm_old(ix_l:ix_h,ny,im) * (-c + ly) &
+          -bxm_old(ix_l:ix_h,ny-1,im) * (-c - ly) &
+          -c * dt * inv_r * etm(ix_l:ix_h,ny-1,im) &
+          + 0.5_num * lx * (brm(ix_l+1:ix_h+1,ny-1,im) &
+          - brm(ix_l:ix_h,ny-1,im) &
+          + brm_old(ix_l+1:ix_h+1,ny-1,im) - brm_old(ix_l:ix_h,ny-1,im)) &
+          - icdt_2r * REAL(im, num) * (erm(ix_l:ix_h,ny,im) &
+          + erm(ix_l:ix_h,ny-1,im)) &
+          - dt_2eps * (jtm(ix_l:ix_h,ny-1,im) + jtm_old(ix_l:ix_h,ny-1,im)))
+
+      btm(1:nx,ny,im) = sum_t * (-btm(1:nx,ny-1,im) * (c - ly + dtc2_4r) &
+          -btm_old(1:nx,ny,im) * (-c + ly + dtc2_4r) &
+          -btm_old(1:nx,ny-1,im) * (-c - ly + dtc2_4r) &
+          - 0.5_num * lx / c * (erm(1:nx,ny,im) + erm(1:nx,ny-1,im) &
+          - erm(0:nx-1,ny,im) - erm(0:nx-1,ny-1,im)) &
+          - icdt_2r * REAL(im, num) * c * (brm(1:nx,ny-1,im) &
+          + brm_old(1:nx,ny-1,im)) &
+          + dt_2eps * (jxm(1:nx,ny-1,im) + jxm_old(1:nx,ny-1,im)))
     END DO
 
   END SUBROUTINE outflow_bcs_r_max


### PR DESCRIPTION
Code can now write and run from restart dumps. Some changes have been made to accomodate this:

- In `outflow_bcs_x_min` and `outflow_bcs_x_max`, we no longer set boundary $\hat{B}_\theta^m$ fields in ghost cells, or $\hat{B}_r^m$ fields on the high $r$ simulation edge.
- In `outflow_bcs_r_max`, $\hat{B}_\theta^m$ is no longer set in the ghost cells, and $\hat{B}_x^m$ is ignored for evaluation points on the simulation $x$ edges.
- When we output fields with stagger in $r$, we output $i_r = 0:n_y - 1$ instead of $i_r = 1:n_y$, as the fields on the $r=0$ axis are important.
- A restart input deck has been provided.

I have confirmed the restarted simulations generate identical results to the simulations run in a single session, in parallel simulations with particles and fields.